### PR TITLE
UInt8 instead of Int8

### DIFF
--- a/bubble_babble.js
+++ b/bubble_babble.js
@@ -14,10 +14,10 @@ var encode = function(input, encoding) {
 
   // create full tuples
   for (i = 0; i + 1 < len; i += 2) {
-    byte1 = input.readInt8(i);
+    byte1 = input.readUInt8(i);
     result += odd_partial(byte1, checksum);
 
-    byte2 = input.readInt8(i + 1);
+    byte2 = input.readUInt8(i + 1);
     d = (byte2 >> 4) & 15;
     e = byte2 & 15;
 
@@ -28,7 +28,7 @@ var encode = function(input, encoding) {
 
   // handle partial tuple
   if (i < len) {
-    byte1 = input.readInt8(i);
+    byte1 = input.readUInt8(i);
     result += odd_partial(byte1, checksum);
   } else {
     result += even_partial(checksum);
@@ -122,6 +122,7 @@ var decode_2part_byte = function(d, e) {
 }
 
 var next_checksum = function(checksum, byte1, byte2) {
+
   return ((checksum * 5) + (byte1 * 7) + byte2) % 36;
 }
 

--- a/bubble_babble.js
+++ b/bubble_babble.js
@@ -122,7 +122,6 @@ var decode_2part_byte = function(d, e) {
 }
 
 var next_checksum = function(checksum, byte1, byte2) {
-
   return ((checksum * 5) + (byte1 * 7) + byte2) % 36;
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -74,11 +74,17 @@ describe('BubbleBabble', function() {
       }).should.throw;
     });
 
-    it('should be inverse of encoding', function() {
+    it('should be inverse of encoding a string', function() {
       var ascii_input = 'Inverse of each other.';
 
       bubble.decode(bubble.encode(ascii_input)).toString().should.equal(ascii_input);
     });
+
+    it('should be inverse of encoding a buffer', function() {
+      var input = Buffer.from('ffffffff','hex');
+
+      bubble.decode(bubble.encode(input)).equals(input).should.be.true;
+    });      
   });
 
 });


### PR DESCRIPTION
Using Int8 means sometimes byte1 and byte2 are negative, which causes trouble with the running checksum, and therefore with the bubble babble encoding.

This wasn't noticed in the tests because all the test data came from strings (where the top bit vanishes anyhow, so nothing was negative).  I've added a test (hex all F) to test for this.